### PR TITLE
Added parameter for resolver name

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -104,6 +104,15 @@ The full url to your Consul server including protocol and port
 
 Default value: $title
 
+##### `resolver_name`
+
+Data type: `String[1]`
+
+The name of the resolver that will be referenced in the balancemember's options
+Defaults to 'consul'
+
+Default value: 'consul'
+
 ##### `resolve_retries`
 
 Data type: `Integer`

--- a/manifests/resolver.pp
+++ b/manifests/resolver.pp
@@ -11,6 +11,9 @@
 #
 # @param consul_server
 #   The full url to your Consul server including protocol and port
+# @param resolver_name
+#   The name of the resolver that will be referenced in the balancemember's options
+#   Defaults to 'consul'
 # @param resolve_retries
 #   Defines the number <nb> of queries to send to resolve a server name before
 #    giving up. Defaults to 3.
@@ -24,6 +27,7 @@
 # @see haproxy::resolver for more details on HAProxy-related parameters
 define haproxy_consul::resolver(
   Stdlib::Httpurl $consul_server = $title,
+  String[1] $resolver_name = 'consul',
   Integer $resolve_retries = 3,
   Hash $timeout = { 'retry' => '2s' },
   Optional[Hash] $hold = undef,
@@ -37,7 +41,7 @@ define haproxy_consul::resolver(
     $memo + { "${nameserver['Node']}" => "${nameserver['Address']}:${consul_dns_port}" }
   }
 
-  haproxy::resolver { 'consul':
+  haproxy::resolver { $resolver_name:
     nameservers           => $nameserver_hash,
     resolve_retries       => $resolve_retries,
     timeout               => $timeout,


### PR DESCRIPTION
Prior to this commit only one resolver could be defined because it was
not possible to change the name of the `haproxy::resolver` resource.